### PR TITLE
Added celery to the stack.

### DIFF
--- a/bpaotu/bpaotu/__init__.py
+++ b/bpaotu/bpaotu/__init__.py
@@ -1,0 +1,5 @@
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/bpaotu/bpaotu/celery.py
+++ b/bpaotu/bpaotu/celery.py
@@ -1,0 +1,20 @@
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+# os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'proj.settings')
+
+app = Celery('bpaotu')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/bpaotu/bpaotu/settings.py
+++ b/bpaotu/bpaotu/settings.py
@@ -290,6 +290,11 @@ LOGGING = {
             'level': 'CRITICAL',
             'propagate': True,
         },
+        'rainbow': {
+            'handlers': ['console', 'file'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
         'bpaotu': {
             'handlers': ['console', 'file'],
             'level': 'DEBUG',
@@ -332,7 +337,6 @@ USE_X_FORWARDED_HOST = env.get("use_x_forwarded_host", True)
 
 # cache using redis
 CACHES = {
-
     'default': {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": env.getlist("cache", ["redis://cache:6379/1"]),
@@ -343,6 +347,21 @@ CACHES = {
         "KEY_PREFIX": "bpaotu_cache"
     }
 }
+
+# Celery
+
+CELERY_BROKER_URL = env.get('CELERY_BROKER_URL', 'redis://cache')
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+# CELERY_TASK_IGNORE_RESULT = True
+
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+
+CELERY_TIMEZONE = TIME_ZONE
+
+# End Celery
+
 CACHES['search_results'] = CACHES['default']
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 

--- a/bpaotu/bpaotu/tasks.py
+++ b/bpaotu/bpaotu/tasks.py
@@ -1,0 +1,6 @@
+from celery import shared_task
+
+
+@shared_task(bind=True)
+def debug_task(self):
+    print('Request: {0!r}'.format(self.request))

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -15,7 +15,7 @@ services:
         - POSTGRES_PASSWORD=webapp
       ports:
         - "5432"
-    
+
     cache:
       image: redis:3-alpine
 
@@ -29,6 +29,13 @@ services:
 
     runserver:
       image: muccg/bpaotu-dev
+      environment:
+        - WAIT_FOR_DB=1
+        - WAIT_FOR_CACHE=1
+
+    celeryworker:
+      image: muccg/bpaotu-dev
+      command: celery_worker
       environment:
         - WAIT_FOR_DB=1
         - WAIT_FOR_CACHE=1

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -30,6 +30,16 @@ services:
          aliases:
            - nginxtest
 
+    celeryworker:
+      extends:
+        file: docker-compose-common.yml
+        service: celeryworker
+      volumes:
+        - uwsgi-prod-data:/data
+      depends_on:
+        - dbprod
+        - cacheprod
+
     uwsgiprod:
       image: muccg/bpaotu:${BUILD_VERSION}
       command: uwsgi_local
@@ -50,7 +60,7 @@ services:
        default:
          aliases:
            - uwsgitest
-           - uwsgi 
+           - uwsgi
 
 volumes:
   uwsgi-prod-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
-      
+
     datadev:
       extends:
         file: docker-compose-common.yml
@@ -40,6 +40,16 @@ services:
         default:
           aliases:
             - web
+
+    celeryworker:
+      extends:
+        file: docker-compose-common.yml
+        service: celeryworker
+      volumes_from:
+        - datadev
+      depends_on:
+        - db
+        - cache
 
     uwsgi:
       extends:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -223,6 +223,15 @@ if [ "$1" = 'runserver_plus' ]; then
     _runserver
 fi
 
+# celery_worker entrypoint
+if [ "$1" = 'celery_worker' ]; then
+    info "[Run] Starting celery_worker"
+
+    set -x
+    exec celery -A bpaotu worker -l info
+fi
+
+
 # runtests entrypoint
 if [ "$1" = 'runtests' ]; then
     info "[Run] Starting tests"

--- a/requirements/runtime-requirements.txt
+++ b/requirements/runtime-requirements.txt
@@ -26,3 +26,4 @@ django-redis==4.8.0
 zipstream==1.1.4
 h5py==2.7.1
 numpy==1.14.1
+celery==4.1.0


### PR DESCRIPTION
Celery 4.1.0.

There is a new container `celeryworker` in the stack that runs the worker.

The tasks should go into `bpaotu/tasks.py`. Tested it from a `shell_plus` by:
```
from bpaotu import tasks as t
t.debug_task.delay()
```
Debug message printed successfully by the celeryworker.

