### PR TITLE
Biom optimisation

### DIFF
--- a/bpaotu/bpaotu/query.py
+++ b/bpaotu/bpaotu/query.py
@@ -20,20 +20,6 @@ from .otu import (
     OTUSpecies,
     SampleContext,
     SampleOTU,
-    SampleAustralianSoilClassification,
-    SampleLandUse,
-    SampleColor,
-    SampleLandUse,
-    SampleFAOSoilClassification,
-    SampleEcologicalZone,
-    SampleHorizonClassification,
-    SampleLandUse,
-    SampleProfilePosition,
-    Environment,
-    SampleType,
-    SampleStorageMethod,
-    SampleTillage,
-    SampleVegetationType,
     make_engine)
 
 
@@ -247,9 +233,13 @@ class SampleQuery:
         # we do a cross-join, but convert to an inner-join with
         # filters. as SampleContext is in the main query, the
         # machinery for filtering above will just work
-        q = self._session.query(OTU)
+        q = self._session.query(OTU) \
+            .filter(SampleOTU.otu_id == OTU.id) \
+            .filter(SampleOTU.sample_id == SampleContext.id)
         q = self._apply_taxonomy_filters(q)
         q = self._contextual_filter.apply(q)
+        q = q.distinct()
+        q = q.order_by(OTU.id)
         if kingdom_id is not None:
             q = q.filter(OTU.kingdom_id == kingdom_id)
         return q

--- a/bpaotu/bpaotu/views.py
+++ b/bpaotu/bpaotu/views.py
@@ -39,9 +39,6 @@ from .models import (
     ImportFileLog,
     ImportOntologyLog,
     ImportSamplesMissingMetadataLog)
-from .settings import (
-    CKAN_AUTH_INTEGRATION
-)
 from .util import val_or_empty
 from .biom import generate_biom_file
 


### PR DESCRIPTION
Speed up export:

 - a bug in the query for the relevant OTUs was doing an unrestricted cross-join between OTUs and Samples, which lead to a huge number of rows
 - we were using `.index` rather than a dictionary for lookups in arrays with thousands of elements
 - we were using `.format` in a busy loop, quite a large speedup by swapping to string primitives

Overall this code is now about 15 times faster