### PR TITLE
encode taxonomy as a JSON array (fixes #44)

### DIFF
--- a/bpaotu/bpaotu/biom.py
+++ b/bpaotu/bpaotu/biom.py
@@ -61,8 +61,8 @@ def otu_rows(query, otu_to_row):
         taxonomy_array = [get_value(f) for f in taxonomy_fields]
         yield '{"id": "%s","metadata": {%s,%s}}' % (
             otu.code,
-            k_v("amplicon", get_value("amplicon")),
-            k_v("taxonomy", taxonomy_array))
+            k_v('amplicon', get_value('amplicon')),
+            k_v('taxonomy', taxonomy_array))
 
 
 def sample_columns(query, sample_to_column):


### PR DESCRIPTION
additionally:

 - add some newlines to the output JSON file to make it a little more
 editor friendly
 - use json.dumps() to marshall out strings, so we're definitely
 escaping safe, and so we can additionally support writing out arrays in
 `k_v`