### PR TITLE
Address last sprint review feedback

### DIFF
--- a/bpaotu/bpaotu/biom.py
+++ b/bpaotu/bpaotu/biom.py
@@ -40,7 +40,7 @@ def biom_zip_file_generator(params, timestamp):
 def save_biom_zip_file(params, dir='/data'):
     timestamp = datetime.datetime.now().replace(microsecond=0).isoformat().replace(':', '')
 
-    filename = os.path.join(dir, 'BiomExport-{}.zip'.format(timestamp))
+    filename = os.path.join(dir, 'BiomExport-{}.biom.zip'.format(timestamp))
     zf = biom_zip_file_generator(params, timestamp)
     with open(filename, 'wb') as f:
         for data in zf:

--- a/bpaotu/bpaotu/ckan_auth.py
+++ b/bpaotu/bpaotu/ckan_auth.py
@@ -22,6 +22,7 @@ class OTUVerificationError(Exception):
 def require_CKAN_auth(func):
     if not settings.CKAN_AUTH_INTEGRATION:
         return func
+
     @wraps(func)
     def inner(request, *args, **kwargs):
         token = request.META.get(settings.CKAN_AUTH_TOKEN_HEADER_NAME)

--- a/bpaotu/bpaotu/tasks.py
+++ b/bpaotu/bpaotu/tasks.py
@@ -67,7 +67,7 @@ def create_history_with_file(submission_id):
     submission.history_id = history.get('id')
 
     filename = os.path.split(full_file_name)[1]
-    file_id = galaxy.histories.upload_file(history.get('id'), full_file_name, filename)
+    file_id = galaxy.histories.upload_file(history.get('id'), full_file_name, filename, file_type='biom1')
 
     submission.file_id = file_id
 

--- a/bpaotu/bpaotu/views.py
+++ b/bpaotu/bpaotu/views.py
@@ -486,7 +486,7 @@ def otu_biom_export(request):
     params, errors = param_to_filters(request.GET['q'])
     zf = biom_zip_file_generator(params, timestamp)
     response = StreamingHttpResponse(zf, content_type='application/zip')
-    filename = 'BiomExport-{}.zip'.format(timestamp)
+    filename = 'BiomExport-{}.biom.zip'.format(timestamp)
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
     return response
 

--- a/requirements/runtime-requirements.txt
+++ b/requirements/runtime-requirements.txt
@@ -23,5 +23,5 @@ django-extensions==1.9.9
 django-redis==4.8.0
 zipstream==1.1.4
 h5py==2.7.1
-numpy==1.14.1
+numpy==1.14.5
 celery==4.1.1


### PR DESCRIPTION
Addresses feedback from the last sprint review:

 - empty strings in contextual metadata field values are now converted into None
 - if a contextual metadata field always have value None for all samples, it is now dropped from the export. this improves UI on Galaxy end, as the blank fields won't appear in drop-down for NMDS plot
 - filename of Zip downloads are now '.biom.zip', this should make it clearer what the underlying filetype is
 - the galaxy filetype 'biom1' is now set when pushing the data to Galaxy
 - performance: had a look at why downloads of large BIOM files took a long time to start returning data. `matching_otus` was doing an unnecessary cross-join; using the approach from `matching_samples` with a subquery to apply contextual filters, and eliding the subquery when possible, greatly improved performance. the previous query required postgres to spool out temporary files before returning any results (hence the long pause); the new query doesn't and commences returning results immediatelyr

Note that a flake8 has been run as well (hence some of the whitespace changes, apologies).
