### PR TITLE
workaround BIOM issues with external tools #82

### DIFF
--- a/bpaotu/bpaotu/biom.py
+++ b/bpaotu/bpaotu/biom.py
@@ -36,7 +36,9 @@ def generate_biom_file(query, comment):
 def biom_zip_file_generator(params, timestamp):
     zf = zipstream.ZipFile(mode='w', compression=zipstream.ZIP_DEFLATED)
     with SampleQuery(params) as query:
-        zf.write_iter(params.filename(timestamp, '.biom'), (s.encode('utf8') for s in generate_biom_file(query, params.describe())))
+        zf.write_iter(
+            params.filename(timestamp, '.biom'),
+            (s.encode('utf8') for s in generate_biom_file(query, params.describe())))
     return zf
 
 


### PR DESCRIPTION
 - all metadata values are strings
 - null -> 'null'
 - add the optional comment field which is used by some tools