### PR TITLE
Fixes #86.

### DIFF
--- a/bpaotu/bpaotu/frontend/src/pages/search_page/reducers/submit_to_galaxy.ts
+++ b/bpaotu/bpaotu/frontend/src/pages/search_page/reducers/submit_to_galaxy.ts
@@ -125,7 +125,7 @@ export default handleActions(
       next: (state, action: any) => {
         const lastSubmission = last(state.submissions)
         const newLastSubmissionState = (submission => {
-          const { status, error, history_id } = action.payload.data.submission
+          const { state: status, error, history_id } = action.payload.data.submission
           const newState = {
             ...submission,
             historyId: history_id,


### PR DESCRIPTION
Renamed state to status when linting to avoid variable hiding, but JSON
still received still had state in it.

Adjusted code to extract the right field.