### PR TITLE
Backend support for running BLAST searches

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   gdal-bin \
   libgeos-3.5.1 \
   libproj-dev \
+  ncbi-blast+ \
   mime-support \
   unixodbc \
   && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/bpaotu/bpaotu/blast.py
+++ b/bpaotu/bpaotu/blast.py
@@ -88,7 +88,7 @@ class BlastWrapper:
         with SampleQuery(self._params) as query:
             q = query.matching_sample_otus(OTU, SampleOTU, SampleContext)
             q = q.filter(OTU.id.in_(blast_rows.keys()))
-            writer = csv.writer(fd, dialect='excel-tab')
+            writer = csv.writer(fd)
             writer.writerow(['OTU', 'sample_id', 'abundance', 'latitude', 'longitude'] + self.BLAST_COLUMNS)
             yield fd.getvalue().encode('utf8')
             fd.seek(0)
@@ -105,7 +105,7 @@ class BlastWrapper:
     def _write_output(self):
         zf = zipstream.ZipFile(mode='w', compression=zipstream.ZIP_DEFLATED)
         zf.writestr('info.txt', self._info_text(self._params))
-        zf.write_iter('blast_results.tsv', self._rewritten_blast_result_rows())
+        zf.write_iter('blast_results.csv', self._rewritten_blast_result_rows())
 
         with suppress(FileExistsError, PermissionError):
             os.mkdir(settings.BLAST_RESULTS_PATH)

--- a/bpaotu/bpaotu/blast.py
+++ b/bpaotu/bpaotu/blast.py
@@ -1,0 +1,117 @@
+from .query import SampleQuery, OTUInfo
+from django.conf import settings
+from . import views
+from contextlib import suppress
+import io
+import shutil
+import csv
+import os.path
+import subprocess
+import logging
+import zipstream
+
+
+logger = logging.getLogger('rainbow')
+
+
+class BlastWrapper:
+    def __init__(self, cwd, submission_id, search_string, query):
+        self._cwd = cwd
+        self._submission_id = submission_id
+        self._search_string = search_string
+        self._query = query
+
+    def setup(self):
+        self._make_database()
+        self._write_query()
+
+    def run(self):
+        self._execute_blast()
+        return self._write_output()
+
+    def cleanup(self):
+        try:
+            shutil.rmtree(self._cwd)
+        except Exception:
+            logger.exception('Error when cleaning up BLAST cwd: ({})'.format(self._cwd))
+
+    def _in(self, filename):
+        "return path to filename within cwd"
+        return os.path.join(self._cwd, filename)
+
+    def _run(self, args):
+        subprocess.run(args, check=True, cwd=self._cwd)
+
+    def _make_database(self):
+        # write user-provided search string into FASTA file
+        with open(self._in('search.fasta'), 'w') as fd:
+            fd.write('> user provided search string\n{}\n'.format(self._search_string))
+        # generate a blast database
+        self._run(
+            ['makeblastdb', '-in', 'search.fasta', '-dbtype', 'nucl', '-parse_seqids'])
+
+    def _write_query(self):
+        with open(self._in('everything.fasta'), 'w') as fasta_fd:
+            # write out the OTU database in FASTA format, as well a
+            # mapping table to get back to the OTU strings
+            params, _ = views.param_to_filters(self._query)
+            with SampleQuery(params) as query:
+                q = query.matching_otus()
+                for idx, otu in enumerate(q.yield_per(50)):
+                    fasta_fd.write('> id_{}\n{}\n\n'.format(otu.id, otu.code))
+
+    def _blast_command(self):
+        return [
+            'blastn', '-db', 'search.fasta', '-query', 'everything.fasta', '-out', 'results.out',
+            '-outfmt', '6 qseqid qlen slen length pident evalue bitscore', '-perc_identity', '95']
+
+    def _execute_blast(self):
+        self._run(self._blast_command())
+
+    def _rewritten_blast_result_rows(self):
+        fd = io.StringIO()
+        with OTUInfo() as info:
+            writer = csv.writer(fd, dialect='excel-tab')
+            writer.writerow(['OTU', 'qlen', 'slen', 'length', 'pident', 'evalue', 'bitscore'])
+            yield fd.getvalue().encode('utf8')
+            fd.seek(0)
+            fd.truncate(0)
+            with open(self._in('results.out')) as results_fd:
+                reader = csv.reader(results_fd, dialect='excel-tab')
+                for row in reader:
+                    otu_id = int(row[0][3:])  # strip id_
+                    otu_code = info.id_to_code(otu_id)
+                    writer.writerow([otu_code] + row[1:])
+                    yield fd.getvalue().encode('utf8')
+                    fd.seek(0)
+                    fd.truncate(0)
+
+    def _write_output(self):
+        zf = zipstream.ZipFile(mode='w', compression=zipstream.ZIP_DEFLATED)
+        params, _ = views.param_to_filters(self._query)
+        zf.writestr('info.txt', self._info_text(params))
+        zf.write_iter('blast_results.tsv', self._rewritten_blast_result_rows())
+
+        with suppress(FileExistsError, PermissionError):
+            os.mkdir(settings.BLAST_RESULTS_PATH)
+
+        fname = 'BlastResults-' + self._submission_id + '.zip'
+        result_path = os.path.join(settings.BLAST_RESULTS_PATH, fname)
+        with open(result_path, 'wb') as fd:
+            for chunk in zf:
+                fd.write(chunk)
+        return fname
+
+    def _info_text(self, params):
+        return """\
+Australian Microbiome OTU Database - BLAST query results
+--------------------------------------------------------
+
+BLAST search executed for:
+{}
+
+Query command line:
+{}
+
+{}
+    """.format(self._search_string, ' '.join(self._blast_command()), params.describe()).encode('utf8')

--- a/bpaotu/bpaotu/blast.py
+++ b/bpaotu/bpaotu/blast.py
@@ -93,7 +93,7 @@ class BlastWrapper:
             yield fd.getvalue().encode('utf8')
             fd.seek(0)
             fd.truncate(0)
-            for i, (otu, sample_otu, sample_context) in enumerate(q.yield_per(50)):
+            for otu, sample_otu, sample_context in q.yield_per(50):
                 blast_row = blast_rows[otu.id]
                 writer.writerow(
                     [otu.code, format_sample_id(sample_context.id), sample_otu.count,

--- a/bpaotu/bpaotu/query.py
+++ b/bpaotu/bpaotu/query.py
@@ -112,6 +112,20 @@ class OTUQueryParams:
             self.taxonomy_filter)
 
 
+class OTUInfo:
+    def __init__(self):
+        self._session = Session()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exec_type, exc_value, traceback):
+        self._session.close()
+
+    def id_to_code(self, otu_id):
+        return self._session.query(OTU.code).filter(OTU.id == otu_id).one()[0]
+
+
 class TaxonomyOptions:
     hierarchy = [
         ('kingdom_id', OTUKingdom),

--- a/bpaotu/bpaotu/query.py
+++ b/bpaotu/bpaotu/query.py
@@ -112,20 +112,6 @@ class OTUQueryParams:
             self.taxonomy_filter)
 
 
-class OTUInfo:
-    def __init__(self):
-        self._session = Session()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exec_type, exc_value, traceback):
-        self._session.close()
-
-    def id_to_code(self, otu_id):
-        return self._session.query(OTU.code).filter(OTU.id == otu_id).one()[0]
-
-
 class TaxonomyOptions:
     hierarchy = [
         ('kingdom_id', OTUKingdom),

--- a/bpaotu/bpaotu/settings.py
+++ b/bpaotu/bpaotu/settings.py
@@ -148,6 +148,11 @@ STATIC_ROOT = env.get('static_root', os.path.join(WEBAPP_ROOT, 'static'))
 STATIC_URL = '{0}/static/'.format(SCRIPT_NAME)
 STATIC_SERVER_PATH = STATIC_ROOT
 
+BLAST_RESULTS_PATH = env.get('blast_results_path', '/data/blast-output/')
+BLAST_RESULTS_URL = env.get('blast_results_url', STATIC_URL)
+STATICFILES_DIRS = [
+    BLAST_RESULTS_PATH,
+]
 MIDDLEWARE_CLASSES = ('django.middleware.security.SecurityMiddleware',
                       'django.middleware.clickjacking.XFrameOptionsMiddleware',
                       'django.middleware.common.CommonMiddleware',

--- a/bpaotu/bpaotu/submission.py
+++ b/bpaotu/bpaotu/submission.py
@@ -9,6 +9,10 @@ redis_client = redis.StrictRedis(host=settings.REDIS_HOST, db=settings.REDIS_DB)
 
 
 class Submission:
+    """
+    track a submission (Galaxy, BLAST, ...) as it progresses
+    """
+
     def __init__(self, submission_id):
         self.submission_id = submission_id
 

--- a/bpaotu/bpaotu/tabular.py
+++ b/bpaotu/bpaotu/tabular.py
@@ -99,7 +99,7 @@ def tabular_zip_file_generator(params):
             fd.seek(0)
             fd.truncate(0)
             q = query.matching_sample_otus(OTU, SampleOTU, SampleContext, kingdom_id=kingdom_id)
-            for i, (otu, sample_otu, sample_context) in enumerate(q.yield_per(50)):
+            for otu, sample_otu, sample_context in q.yield_per(50):
                 w.writerow([
                     format_sample_id(sample_otu.sample_id),
                     otu.code,

--- a/bpaotu/bpaotu/urls.py
+++ b/bpaotu/bpaotu/urls.py
@@ -18,6 +18,8 @@ urlpatterns = [
     url(r'^private/api/v1/search-sample-sites$', views.otu_search_sample_sites, name="otu_search_sample_sites"),
     url(r'^private/api/v1/submit_to_galaxy$', views.submit_to_galaxy, name="submit_to_galaxy"),
     url(r'^private/api/v1/galaxy_submission$', views.galaxy_submission, name="galaxy_submission"),
+    url(r'^private/api/v1/submit_blast$', views.submit_blast, name="submit_blast"),
+    url(r'^private/api/v1/blast_submission$', views.blast_submission, name="blast_submission"),
     url(r'^private/api/v1/export$', views.otu_export, name="otu_export"),
     url(r'^private/api/v1/export_biom$', views.otu_biom_export, name="otu_biom_export"),
     url(

--- a/bpaotu/bpaotu/views.py
+++ b/bpaotu/bpaotu/views.py
@@ -132,10 +132,6 @@ def make_clean_taxonomy_filter(amplicon_filter, state_vector):
 
 
 def normalise_blast_search_string(s):
-    """
-    returns None if the string is valid
-    otherwise, returns the set of invalid characters
-    """
     cleaned = s.strip().upper()
     used_chars = set(cleaned)
     permitted_chars = set('GATC')

--- a/requirements/runtime-requirements.txt
+++ b/requirements/runtime-requirements.txt
@@ -29,7 +29,7 @@ celery==4.1.1
 Pillow==5.3.0
 python-resize-image==1.1.18
 django-webpack-loader==0.6.0
-https://github.com/BioplatformsAustralia/bpa-ingest/archive/5.3.3.tar.gz
+https://github.com/BioplatformsAustralia/bpa-ingest/archive/5.3.7.tar.gz
 git+https://github.com/muccg/ckanapi.git@streaming-uploads
 httplib2==0.10.3
 boto3==1.4.7


### PR DESCRIPTION
 - output to a directory and URL prefix specified by settings
 - for local dev, this directory is served out via staticfiles
 - add blast+ to the image, so it can be run by the celery worker
 - add a URL endpoint, /submit_blast, which kicks off a BLAST job
 - add a URL endpoint, /blast_submission, which reports that status
 of a BLAST job
 - BLAST is executed using the parameters provided by Andrew B.
 Temporary FASTA files are written so that the chosen subset of the
 database can be blasted against. The output of BLAST is read and
 remapped against the OTU database to replace integers IDs with
 the full OTU codes, working around maximum ID limit in BLAST.