### PR TITLE
update ingest for latest CSIRO data format

### DIFF
--- a/bpaotu/bpaotu/importer.py
+++ b/bpaotu/bpaotu/importer.py
@@ -255,7 +255,8 @@ class DataImporter:
                         if amplicon is None:
                             amplicon = obj['amplicon']
                         if amplicon != obj['amplicon']:
-                            raise Exception('more than one amplicon in folder: {} vs {}'.format(amplicon, obj['amplicon']))
+                            raise Exception(
+                                'more than one amplicon in folder: {} vs {}'.format(amplicon, obj['amplicon']))
                         obj.update(zip(taxo_header, row[1:-1]))
                         yield obj
                 self.amplicon_code_names[amplicon_code] = amplicon

--- a/bpaotu/bpaotu/views.py
+++ b/bpaotu/bpaotu/views.py
@@ -533,7 +533,7 @@ def otu_log(request):
         'ckan_base_url': settings.CKAN_SERVER['base_url'],
         'files': ImportFileLog.objects.all(),
         'ontology_errors': ImportOntologyLog.objects.all(),
-        'missing_samples': sorted(missing_sample_ids),
+        'missing_samples': sorted(missing_sample_ids, key=lambda x: int(x)),
         'metadata': import_meta,
     }
     return HttpResponse(template.render(context, request))


### PR DESCRIPTION
 - OTU codes are no longer globally unique, they are unique
   per-amplicon. They probably were before, but it had never come up.
 - fix the ordering of sample IDs on the ingest report page
 - enforce that sample IDs are integers, OTU codes are GATTACA strings