### PR TITLE
Undo debugging loggin and fix csv headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bpaotu/bpaotu/frontend/dist
 bpaotu/bpaotu/static/bpaotu/js/*-bundle*.js
 
 .env
+_skip_warmcache
 
 yarn_cache/
 .DS_Store

--- a/bpaotu/bpaotu/importer.py
+++ b/bpaotu/bpaotu/importer.py
@@ -495,7 +495,7 @@ class DataImporter:
                 self.save_ontology_errors(
                     getattr(contextual_source, "environment_ontology_errors", None))
                 for sample_id in contextual_source.sample_ids():
-                    metadata[sample_id]['sample_id'] = sample_id # debug: sample_id must be a tuple for error to occur?
+                    metadata[sample_id]['sample_id'] = sample_id
                     metadata[sample_id].update(contextual_source.get(sample_id))
 
         def has_minimum_metadata(row):
@@ -505,21 +505,8 @@ class DataImporter:
         rows = []
         for entry in metadata.values():
             if not has_minimum_metadata(entry):
-                logger.info('if not has_minimum_metadata(entry):')
-                logger.info('type(entry)')
-                logger.info(type(entry))
-                logger.info('entry')
-                logger.info(entry)
-                logger.info('type(entry[\'sample_id\'])')
-                logger.info(type(entry['sample_id']))
-                logger.info('entry[\'sample_id\']')
-                logger.info(entry['sample_id'])
-
-                # debug: entry['sample_id'] must be a tuple for this error to occur (line number will be different with this logging code)
-                # File "/env/lib/python3.8/site-packages/bpaotu/importer.py", line 509, in contextual_rows
-                #     entry['sample_id'].split('/')[-1])
-                # AttributeError: 'tuple' object has no attribute 'split'
-                self.sample_metadata_incomplete.add(entry['sample_id'].split('/')[-1])
+                self.sample_metadata_incomplete.add(
+                    entry['sample_id'].split('/')[-1])
                 continue
             rows.append(entry)
         return rows

--- a/bpaotu/bpaotu/query.py
+++ b/bpaotu/bpaotu/query.py
@@ -146,6 +146,9 @@ class OTUQueryParams:
                 indent + 'Dataset methodology={}'.format(metadata.methodology),
                 indent + 'Dataset analysis url={}'.format(metadata.analysis_url),
                 indent + 'Dataset revision date={}'.format(metadata.revision_date),
+                indent + 'Dataset revision date={}'.format(metadata.revision_date),
+                '',
+                'For the schema definition refer to the location provided in the database_schema_definitions_url column'
             ]
 
         add_section(amplicon_section())

--- a/bpaotu/bpaotu/tabular.py
+++ b/bpaotu/bpaotu/tabular.py
@@ -43,23 +43,23 @@ def _csv_write_function(column):
     else:
         return str_none_blank
 
+def _csv_units_heading(column, field_units):
+    return field_units.get(column.name)
 
-def _csv_heading(column, field_units):
-    units = field_units.get(column.name)
+def _csv_field_heading(column):
     if column.name == 'id':
-        return 'Sample ID'
-    title = SampleContext.display_name(column.name)
-    if units:
-        title += ' [%s]' % units
-    return title
+        return 'sample_id'
+    return SampleContext.csv_header_name(column.name)
 
 
 def contextual_csv(samples):
-    headings = {}
+    units_headings = {}
+    field_headings = {}
     write_fns = {}
     field_units = AustralianMicrobiomeSampleContextual.units_for_fields()
     for column in SampleContext.__table__.columns:
-        headings[column.name] = _csv_heading(column, field_units)
+        units_headings[column.name] = _csv_units_heading(column, field_units)
+        field_headings[column.name] = _csv_field_heading(column)
         write_fns[column.name] = _csv_write_function(column)
 
     def get_context_value(sample, field):
@@ -75,7 +75,8 @@ def contextual_csv(samples):
 
     csv_fd = io.StringIO()
     w = csv.writer(csv_fd)
-    w.writerow(headings[t] for t in fields)
+    w.writerow(units_headings[t] for t in fields)
+    w.writerow(field_headings[t] for t in fields)
     yield csv_fd.getvalue().encode('utf8')
 
     for sample in samples:

--- a/bpaotu/bpaotu/views.py
+++ b/bpaotu/bpaotu/views.py
@@ -310,7 +310,7 @@ def contextual_fields(request):
         [make_defn('float', field_name) for field_name in fields_by_type['FLOAT']] +
         [make_defn('string', field_name) for field_name in fields_by_type['CITEXT']] +
         [make_defn('ontology', field_name, values=values) for field_name, values in fields_with_values])
-    definitions.sort(key=itemgetter('display_name'))
+    definitions.sort(key=lambda a: a['display_name'].lower())
 
     return JsonResponse({
         'definitions': definitions,


### PR DESCRIPTION
CSV headers now match schema definition, rather than title case and spaces for underscores
Units have been removed and added as an extra row above the field name, so when people read it into R, pandas or whatever they can pretty easily skip the first row if needed

Also has better handling of when to remove the `_id` suffix  from a field name (only do this when the column in the sample context table has _id because it links to an ontology table); and some cosmetic capitalisation (i.e convert " Id" to " ID" and "Ph" to "pH")