### PR TITLE
Submodule remove

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bpa-ingest"]
-	path = bpa-ingest
-	url = https://github.com/BioplatformsAustralia/bpa-ingest.git

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -37,8 +37,7 @@ RUN git rev-parse HEAD | tee .version
 
 RUN pip install --upgrade -r requirements/runtime-requirements.txt \
 && pip install --upgrade -r requirements/biom-requirements.txt \
-&& cd "${WORKINGDIR}/${PROJECT_NAME}" && pip install . \
-&& cd "${WORKINGDIR}/bpa-ingest" && poetry build -f wheel && pip install `ls dist/bpaingest-*.whl`
+&& cd "${WORKINGDIR}/${PROJECT_NAME}" && pip install
 
 ADD build/frontend.tgz /data/app/bpaotu/bpaotu/static/bpaotu
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -45,14 +45,6 @@ RUN pip install --upgrade -r bpaotu/biom-requirements.txt
 # Copy code and install the app
 COPY . /app
 RUN pip ${PIP_OPTS} install --upgrade -e bpaotu
-WORKDIR /app/bpa-ingest
-
-RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir poetry
-RUN poetry config virtualenvs.create false
-RUN poetry build -f wheel
-RUN pip install `ls dist/bpaingest-*.whl`
-# RUN pip uninstall --yes poetry
 
 EXPOSE 8000 9000 9001 9100 9101
 VOLUME ["/app", "/data"]

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ developed to access data from the Australian Microbiome.
   metagenome data). For this reason the docker containers (at least `runserver`
   and `celeryworker`) need to run with a valid CKAN_API_KEY environment
   variable (see ./.env_local and ./docker-compose.yml).
-- It uses a git submodule `bpa-ingest`, maintained externally. It's important to
-  update this submodule frequently in order to be able to ingest the latest
-  version of the sample context metadata.
+- It depends on another Bioplatforms Australia project called `bpa-ingest`
+  [(maintained externally)](https://github.com/BioplatformsAustralia/bpa-ingest).
+  The version of `bpa-ingest` used is maintained in the `runtime-requirements.txt` file.
+  When updating the AM metadata schema, the `bpa-ingest` repository requires changes.
+  These changes will be associated with a git tag by the `bpa-ingest` team for the new version.
+  The entry in `runtime-requirements.txt` must be updated to use the version at this new tag.
+  Note: This dependency was handled previously as a git submodule.
 - For development, Django runs in a Docker container, while the frontend
   webserver is started from a shell prompt outside of the container. The
   container mounts `./` as a volume, which means that Django will monitor all of
@@ -41,7 +45,6 @@ developed to access data from the Australian Microbiome.
   - Note: the Docker compose plugin (`docker compose`) does not seem to work with the docker-compose-build.yml file, but the older executable (`docker-compose`) does work
   - On the docker compose install page, there is a note that Compose V1 won't be supported anymore
     from the end of June 2023 (which may affect these steps)
-- `git clone --recurse-submodules` [https://github.com/BioplatformsAustralia/bpaotu.git](https://github.com/BioplatformsAustralia/bpaotu.git)
 - Generate `./.env_local`. This should contain `KEY=value` lines. See `./.env`
   for keys. This must have a valid `CKAN_API_KEY` so that site images and sample
   metagenome data can be fetched during development. You can use your personal

--- a/requirements/runtime-requirements.txt
+++ b/requirements/runtime-requirements.txt
@@ -28,6 +28,7 @@ Pillow>=8.1.1
 python-resize-image==1.1.19
 django-webpack-loader==0.7.0
 git+https://github.com/BioplatformsAustralia/ckanapi.git@streaming-uploads
+git+https://github.com/BioplatformsAustralia/bpa-ingest.git@master
 httplib2==0.17.2
 google-api-python-client
 python-dateutil==2.8.1

--- a/requirements/runtime-requirements.txt
+++ b/requirements/runtime-requirements.txt
@@ -7,7 +7,7 @@ boto==2.49.0
 ccg-django-utils==0.4.2
 psycopg2==2.8.5
 pytz==2019.3
-requests==2.23.0
+requests==2.31.0
 six==1.14.0
 uwsgi==2.0.18
 uwsgitop==0.11
@@ -32,7 +32,6 @@ git+https://github.com/BioplatformsAustralia/bpa-ingest.git@master
 httplib2==0.17.2
 google-api-python-client
 python-dateutil==2.8.1
-shapely==1.7.0
 django-anymail[amazon_ses]==7.1.0
 reportlab==4.0.9
 xhtml2pdf==0.2.6

--- a/requirements/runtime-requirements.txt
+++ b/requirements/runtime-requirements.txt
@@ -28,7 +28,7 @@ Pillow>=8.1.1
 python-resize-image==1.1.19
 django-webpack-loader==0.7.0
 git+https://github.com/BioplatformsAustralia/ckanapi.git@streaming-uploads
-git+https://github.com/BioplatformsAustralia/bpa-ingest.git@master
+git+https://github.com/BioplatformsAustralia/bpa-ingest.git@6.10.18
 httplib2==0.17.2
 google-api-python-client
 python-dateutil==2.8.1


### PR DESCRIPTION
Remove the bpa-ingest dependency as a submodule and instead include it in the python requirements.txt file
This means when building the container the specified version of bpa-ingest in `runtime-requirements.txt` will be used, rather than having to update the submodule to a commit for a more recent version