### PR TITLE
Add distinct clause to fasta rows query.

### DIFF
--- a/bpaotu/bpaotu/query.py
+++ b/bpaotu/bpaotu/query.py
@@ -477,7 +477,8 @@ class SampleQuery:
                 .query(OTU.code, Sequence.seq)\
                 .filter(OTU.id == SampleOTU.otu_id)\
                 .join(Taxonomy.otus)\
-                .join(Sequence, Sequence.id == OTU.id)
+                .join(Sequence, Sequence.id == OTU.id)\
+                .distinct()
 
         q = self.apply_sample_otu_filters(q)
 


### PR DESCRIPTION
Dramatically reduces uncompressed filesize, with the trade off being slightly longer to start the zipstream (total time sometimes faster and sometimes slower)